### PR TITLE
saveAll을 하나의 쿼리로 처리한다

### DIFF
--- a/src/main/java/hiyen/galmanhae/dataprocess/DataProcessor.java
+++ b/src/main/java/hiyen/galmanhae/dataprocess/DataProcessor.java
@@ -45,7 +45,6 @@ public class DataProcessor {
 			.map(CompletableFuture::join)
 			.filter(Objects::nonNull)
 			.toList();
-
 		dataQueryService.saveAllPlaces(places);
 	}
 

--- a/src/main/java/hiyen/galmanhae/dataprocess/application/DataQueryService.java
+++ b/src/main/java/hiyen/galmanhae/dataprocess/application/DataQueryService.java
@@ -1,9 +1,7 @@
 package hiyen.galmanhae.dataprocess.application;
 
-import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo;
 import hiyen.galmanhae.place.domain.place.Place;
-import hiyen.galmanhae.place.entity.PlaceEntity;
-import hiyen.galmanhae.place.entity.PlaceInfoEntity;
+import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo;
 import hiyen.galmanhae.place.repository.PlaceInfoRepository;
 import hiyen.galmanhae.place.repository.PlaceRepository;
 import java.util.List;
@@ -18,25 +16,14 @@ public class DataQueryService {
 	private final PlaceInfoRepository placeInfoRepository;
 
 	public void saveAllPlaces(final List<Place> places) {
-		//TODO 벌크 insert로 변경예정
-		final List<PlaceEntity> list = places.stream()
-			.map(PlaceEntity::from)
-			.toList();
-		placeRepository.saveAll(list);
+		placeRepository.saveAll(places);
 	}
 
 	public void saveAllPlaceInfos(final List<PlaceInfo> placeInfos) {
-		//TODO 벌크 insert로 변경예정
-		final List<PlaceInfoEntity> list = placeInfos.stream()
-			.map(PlaceInfoEntity::from)
-			.toList();
-		placeInfoRepository.saveAll(list);
+		placeInfoRepository.saveAll(placeInfos);
 	}
 
 	public List<PlaceInfo> findAllPlaceInfos() {
-		final List<PlaceInfoEntity> found = placeInfoRepository.findAll();
-		return found.stream()
-			.map(PlaceInfoEntity::toPlaceInfo)
-			.toList();
+		return placeInfoRepository.findAll();
 	}
 }

--- a/src/main/java/hiyen/galmanhae/place/entity/PlaceEntity.java
+++ b/src/main/java/hiyen/galmanhae/place/entity/PlaceEntity.java
@@ -10,28 +10,24 @@ import hiyen.galmanhae.place.domain.place.Weather;
 import hiyen.galmanhae.place.domain.place.WeatherLevel;
 import hiyen.galmanhae.place.domain.place.WeatherLevel.WeatherRainingGrade;
 import hiyen.galmanhae.place.domain.place.WeatherLevel.WeatherTempGrade;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Entity
+@Table(name = "place")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class PlaceEntity extends BaseEntity {
+@ToString
+public class PlaceEntity {
 
 	@Id
 	@Column(name = "place_id")
@@ -39,6 +35,7 @@ public class PlaceEntity extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Getter
 	@Column(name = "place_name")
 	private String name;
 
@@ -55,14 +52,17 @@ public class PlaceEntity extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	private GoOutLevel goOutLevel;
 
+	private LocalDateTime createdAt;
+
 	@Builder
 	public PlaceEntity(
 		final String name,
 		final LocationEntity location,
 		final WeatherEntity weather,
 		final CongestionEntity congestion,
-		final GoOutLevel goOutLevel) {
-		this(null, name, location, weather, congestion, goOutLevel);
+		final GoOutLevel goOutLevel,
+		final LocalDateTime createdAt) {
+		this(null, name, location, weather, congestion, goOutLevel, createdAt);
 	}
 
 	public static PlaceEntity from(final Place place) {
@@ -88,6 +88,7 @@ public class PlaceEntity extends BaseEntity {
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor
 	@Getter
+	@ToString
 	public static class LocationEntity {
 
 		@Column(name = "latitude")
@@ -109,6 +110,7 @@ public class PlaceEntity extends BaseEntity {
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor
 	@Getter
+	@ToString
 	public static class WeatherEntity {
 
 		@Column(name = "weather_temp")
@@ -140,6 +142,7 @@ public class PlaceEntity extends BaseEntity {
 		@NoArgsConstructor(access = AccessLevel.PROTECTED)
 		@AllArgsConstructor
 		@Getter
+		@ToString
 		public static class WeatherLevelEntity {
 
 			@Column(name = "weather_raining_grade")
@@ -175,6 +178,7 @@ public class PlaceEntity extends BaseEntity {
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor
 	@Getter
+	@ToString
 	public static class CongestionEntity {
 
 		@Column(name = "congestion_people")

--- a/src/main/java/hiyen/galmanhae/place/entity/PlaceInfoEntity.java
+++ b/src/main/java/hiyen/galmanhae/place/entity/PlaceInfoEntity.java
@@ -4,6 +4,7 @@ import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo;
 import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo.AreaInfo;
 import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo.LocationInfo;
 import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo.WeatherInfo;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -15,12 +16,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Table(name = "place_info")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 public class PlaceInfoEntity {
 
 	@Id
@@ -63,7 +66,10 @@ public class PlaceInfoEntity {
 	@NoArgsConstructor
 	public static class AreaInfoEntity {
 
+		@Column(name = "area_code", length = 10)
 		private String areaCode;
+
+		@Column(name = "area_name")
 		private String areaName;
 	}
 
@@ -73,7 +79,10 @@ public class PlaceInfoEntity {
 	@NoArgsConstructor
 	public static class LocationInfoEntity {
 
+		@Column(name = "latitude")
 		private String latitude;
+
+		@Column(name = "longitude")
 		private String longitude;
 	}
 
@@ -83,7 +92,10 @@ public class PlaceInfoEntity {
 	@NoArgsConstructor
 	public static class WeatherInfoEntity {
 
+		@Column(name = "weather_x", length = 5)
 		private String weatherX;
+
+		@Column(name = "weather_y", length = 5)
 		private String weatherY;
 	}
 }

--- a/src/main/java/hiyen/galmanhae/place/repository/PlaceInfoRepository.java
+++ b/src/main/java/hiyen/galmanhae/place/repository/PlaceInfoRepository.java
@@ -1,8 +1,15 @@
 package hiyen.galmanhae.place.repository;
 
-import hiyen.galmanhae.place.entity.PlaceInfoEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
+import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo;
+import java.util.List;
 
-public interface PlaceInfoRepository extends JpaRepository<PlaceInfoEntity, Long>{
+public interface PlaceInfoRepository {
 
+	List<PlaceInfo> saveAll(List<PlaceInfo> placeInfos);
+
+	List<PlaceInfo> findAll();
+
+	long count();
+
+	PlaceInfo save(PlaceInfo place);
 }

--- a/src/main/java/hiyen/galmanhae/place/repository/PlaceRepository.java
+++ b/src/main/java/hiyen/galmanhae/place/repository/PlaceRepository.java
@@ -1,10 +1,13 @@
 package hiyen.galmanhae.place.repository;
 
-import hiyen.galmanhae.place.entity.PlaceEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import hiyen.galmanhae.place.domain.place.Place;
+import java.util.List;
 
-@Repository
-public interface PlaceRepository extends JpaRepository<PlaceEntity, Long> {
+public interface PlaceRepository {
 
+	List<Place> saveAll(List<Place> placeEntities);
+
+	List<Place> findAll();
+
+	long count();
 }

--- a/src/main/java/hiyen/galmanhae/place/repository/place/PlaceJpaRepository.java
+++ b/src/main/java/hiyen/galmanhae/place/repository/place/PlaceJpaRepository.java
@@ -1,0 +1,8 @@
+package hiyen.galmanhae.place.repository.place;
+
+import hiyen.galmanhae.place.entity.PlaceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceJpaRepository extends JpaRepository<PlaceEntity, Long> {
+
+}

--- a/src/main/java/hiyen/galmanhae/place/repository/place/PlaceRepositoryImpl.java
+++ b/src/main/java/hiyen/galmanhae/place/repository/place/PlaceRepositoryImpl.java
@@ -1,0 +1,78 @@
+package hiyen.galmanhae.place.repository.place;
+
+import hiyen.galmanhae.place.domain.place.Place;
+import hiyen.galmanhae.place.entity.PlaceEntity;
+import hiyen.galmanhae.place.repository.PlaceRepository;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PlaceRepositoryImpl implements PlaceRepository {
+
+	private final PlaceJpaRepository placeJpaRepository;
+	private final JdbcTemplate jdbcTemplate;
+
+	public PlaceRepositoryImpl(final PlaceJpaRepository placeJpaRepository, final DataSource dataSource) {
+		this.placeJpaRepository = placeJpaRepository;
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	@Override
+	public List<Place> saveAll(final List<Place> places) {
+		final List<PlaceEntity> entities = toEntities(places);
+
+		final String sql = """
+			INSERT INTO place (place_name, latitude, longitude, weather_temp, weather_raining, weather_raining_grade, weather_temp_grade, 
+			weather_score, congestion_people, congestion_level, go_out_level, created_at) 
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, now())
+			""";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				final PlaceEntity place = entities.get(i);
+				ps.setString(1, place.getName());
+				ps.setDouble(2, place.getLocation().getLatitude());
+				ps.setDouble(3, place.getLocation().getLongitude());
+				ps.setDouble(4, place.getWeather().getWeatherTemp());
+				ps.setDouble(5, place.getWeather().getWeatherRaining());
+				ps.setString(6, place.getWeather().getWeatherLevel().getWeatherRainingGrade().name());
+				ps.setString(7, place.getWeather().getWeatherLevel().getWeatherTempGrade().name());
+				ps.setInt(8, place.getWeather().getWeatherLevel().getWeatherScore());
+				ps.setInt(9, place.getCongestion().getCongestionPeople());
+				ps.setString(10, place.getCongestion().getCongestionLevel().name());
+				ps.setString(11, place.getGoOutLevel().name());
+			}
+
+			@Override
+			public int getBatchSize() {
+				return entities.size();
+			}
+		});
+
+		return places;
+	}
+
+	@Override
+	public List<Place> findAll() {
+		return placeJpaRepository.findAll().stream()
+			.map(PlaceEntity::toPlace)
+			.toList();
+	}
+
+	@Override
+	public long count() {
+		return placeJpaRepository.count();
+	}
+
+	private static List<PlaceEntity> toEntities(final List<Place> places) {
+		return places.stream()
+			.map(PlaceEntity::from)
+			.toList();
+	}
+}

--- a/src/main/java/hiyen/galmanhae/place/repository/placeinfo/PlaceInfoJpaRepository.java
+++ b/src/main/java/hiyen/galmanhae/place/repository/placeinfo/PlaceInfoJpaRepository.java
@@ -1,0 +1,8 @@
+package hiyen.galmanhae.place.repository.placeinfo;
+
+import hiyen.galmanhae.place.entity.PlaceInfoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceInfoJpaRepository extends JpaRepository<PlaceInfoEntity, Long> {
+
+}

--- a/src/main/java/hiyen/galmanhae/place/repository/placeinfo/PlaceInfoRepositoryImpl.java
+++ b/src/main/java/hiyen/galmanhae/place/repository/placeinfo/PlaceInfoRepositoryImpl.java
@@ -1,0 +1,78 @@
+package hiyen.galmanhae.place.repository.placeinfo;
+
+import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo;
+import hiyen.galmanhae.place.entity.PlaceInfoEntity;
+import hiyen.galmanhae.place.repository.PlaceInfoRepository;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PlaceInfoRepositoryImpl implements PlaceInfoRepository {
+
+	private final PlaceInfoJpaRepository placeInfoJpaRepository;
+	private final JdbcTemplate jdbcTemplate;
+
+	public PlaceInfoRepositoryImpl(final PlaceInfoJpaRepository placeInfoJpaRepository, final DataSource dataSource) {
+		this.placeInfoJpaRepository = placeInfoJpaRepository;
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	@Override
+	public List<PlaceInfo> saveAll(final List<PlaceInfo> placeInfos) {
+		final List<PlaceInfoEntity> entities = toEntities(placeInfos);
+
+		final String sql = """
+			INSERT INTO place_info (area_code, area_name, latitude, longitude, weather_x, weather_y)
+			VALUES (?, ?, ?, ?, ?, ?)
+			""";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(final PreparedStatement ps, final int i) throws SQLException {
+				final PlaceInfoEntity entity = entities.get(i);
+				ps.setString(1, entity.getAreaInfo().getAreaCode());
+				ps.setString(2, entity.getAreaInfo().getAreaName());
+				ps.setString(3, entity.getLocationInfo().getLatitude());
+				ps.setString(4, entity.getLocationInfo().getLongitude());
+				ps.setString(5, entity.getWeatherInfo().getWeatherX());
+				ps.setString(6, entity.getWeatherInfo().getWeatherY());
+			}
+
+			@Override
+			public int getBatchSize() {
+				return entities.size();
+			}
+		});
+
+		return placeInfos;
+	}
+
+	@Override
+	public List<PlaceInfo> findAll() {
+		return placeInfoJpaRepository.findAll().stream()
+			.map(PlaceInfoEntity::toPlaceInfo)
+			.toList();
+	}
+
+	@Override
+	public long count() {
+		return placeInfoJpaRepository.count();
+	}
+
+	@Override
+	public PlaceInfo save(final PlaceInfo placeInfo) {
+		final PlaceInfoEntity save = placeInfoJpaRepository.save(PlaceInfoEntity.from(placeInfo));
+		return PlaceInfoEntity.toPlaceInfo(save);
+	}
+
+	private static List<PlaceInfoEntity> toEntities(final List<PlaceInfo> placeInfos) {
+		return placeInfos.stream()
+			.map(PlaceInfoEntity::from)
+			.toList();
+	}
+}

--- a/src/test/java/hiyen/galmanhae/dataprocess/DataProcessTest.java
+++ b/src/test/java/hiyen/galmanhae/dataprocess/DataProcessTest.java
@@ -1,6 +1,6 @@
 package hiyen.galmanhae.dataprocess;
 
-import hiyen.galmanhae.place.entity.PlaceEntity;
+import hiyen.galmanhae.place.domain.place.Place;
 import hiyen.galmanhae.place.repository.PlaceInfoRepository;
 import hiyen.galmanhae.place.repository.PlaceRepository;
 import java.util.List;
@@ -34,10 +34,8 @@ public class DataProcessTest {
 		placeInfoDataProcessor.process();
 		dataProcessor.process();
 
-		List<PlaceEntity> all = placeRepository.findAll();
-		all.stream()
-			.map(PlaceEntity::toPlace)
-			.forEach(System.out::println);
+		List<Place> all = placeRepository.findAll();
+		all.forEach(System.out::println);
 		System.out.println(all.size());
 	}
 }

--- a/src/test/java/hiyen/galmanhae/dataprocess/DataProcessorIntegrationTest.java
+++ b/src/test/java/hiyen/galmanhae/dataprocess/DataProcessorIntegrationTest.java
@@ -4,10 +4,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import hiyen.galmanhae.place.entity.PlaceInfoEntity;
-import hiyen.galmanhae.place.entity.PlaceInfoEntity.AreaInfoEntity;
-import hiyen.galmanhae.place.entity.PlaceInfoEntity.LocationInfoEntity;
-import hiyen.galmanhae.place.entity.PlaceInfoEntity.WeatherInfoEntity;
+import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo;
+import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo.AreaInfo;
+import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo.LocationInfo;
+import hiyen.galmanhae.place.domain.placeinfo.PlaceInfo.WeatherInfo;
 import hiyen.galmanhae.place.repository.PlaceInfoRepository;
 import hiyen.galmanhae.place.repository.PlaceRepository;
 import java.io.IOException;
@@ -38,12 +38,12 @@ class DataProcessorIntegrationTest extends MockAPI {
 
 	@BeforeEach
 	void setUp() {
-		final PlaceInfoEntity placeInfoEntity = PlaceInfoEntity.builder()
-			.areaInfo(new AreaInfoEntity("POI001", "강남 MICE 관광특구"))
-			.locationInfo(new LocationInfoEntity("37.5112843816696", "127.06005155384705"))
-			.weatherInfo(new WeatherInfoEntity("62", "127"))
-			.build();
-		placeInfoRepository.save(placeInfoEntity);
+		final PlaceInfo placeInfo = new PlaceInfo(
+			new AreaInfo(areaCode, "강남구"),
+			new LocationInfo("37.1234", "127.1234"),
+			new WeatherInfo("60", "127")
+		);
+		placeInfoRepository.save(placeInfo);
 	}
 
 	@DisplayName("외부 API를 호출하여 데이터를 DB에 저장한다")


### PR DESCRIPTION
#### PR 설명

~~(#14 의 커밋이 반영되어 있습니다. #14가 merge되면 rebase하여 해당 이슈관련 커밋만 남기도록 하겠습니다. 이 PR에서 보실 주요 커밋은 [886d4d4](https://github.com/jinkshower/galmanhae/commit/886d4d4119e9ddfeadd3259934614408dc2ac004)입니다. [28f1911](https://github.com/jinkshower/galmanhae/commit/28f1911b6196dd378c36cdfdd3efc6cfe0c2ef27), [916ab6e](https://github.com/jinkshower/galmanhae/commit/916ab6edcd45ef290f5e67163a8f1f226f359e6e)은 변경에 맞춰 정리하는 커밋들입니다.~~

Closes #11 

- saveAll에 jdbcTemplate의 batchupdate 적용

Repository를 인터페이스화하고 JpaRepository, jdbctemplate를 구현체에서 사용하는 방식으로 변경했습니다. 현재 Identity전략으로 PK를 사용하고 있어 bulk insert는 jdbctemplate를 사용했습니다

db관련 기술을 원하는대로 적용하기 쉽고 이후 단위 테스트시 db를 mocking하기에 용이할 거라 판단되어 추상화를 적용했습니다. #4를 적용한 상태라 repository 구현체 내에서만 entity를 사용하게 했습니다. 비즈니스 로직에 entity가 없다면 더 수정이 쉬워질거라 판단했습니다.



#### PR전 체크리스트

- [x] 코드 포맷터를 적용했습니다
- [ ] 변경에 해당하는 테스트(단위 or 통합)를 작성했습니다
