### PR TITLE
DataProcess 패키지의 데이터 처리를 자동화한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
+    testImplementation 'org.mockito:mockito-core:4.8.0'
 
     // OpenFeign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/src/main/java/hiyen/galmanhae/dataprocess/DataProcessInitializer.java
+++ b/src/main/java/hiyen/galmanhae/dataprocess/DataProcessInitializer.java
@@ -1,0 +1,38 @@
+package hiyen.galmanhae.dataprocess;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Profile("prod")
+@RequiredArgsConstructor
+@Component
+public class DataProcessInitializer {
+
+	private final PlaceInfoDataProcessor placeInfoDataProcessor;
+	private final DataProcessor dataProcessor;
+
+	/**
+	 * 애플리케이션 시작시 장소 목록을 다운로드 이후 DB에 저장
+	 * 해당 장소 목록을 읽어 외부 API를 호출하여 데이터를 가져오고 Place 테이블에 저장
+	 */
+	@PostConstruct
+	public void init() {
+		log.info("애플리케이션이 시작되고 데이터 처리를 시작합니다");
+		placeInfoDataProcessor.process();
+		dataProcessor.process();
+		log.info("데이터 처리가 완료되었습니다.");
+	}
+
+	/**
+	 * 매 시간마다 외부 API를 호출하여 데이터를 가져오고 Place 테이블에 저장
+	 */
+	@Scheduled(cron = "0 0 * * * ?")
+	public void hourlyProcess() {
+		dataProcessor.process();
+	}
+}

--- a/src/main/java/hiyen/galmanhae/dataprocess/PlaceInfoDataProcessor.java
+++ b/src/main/java/hiyen/galmanhae/dataprocess/PlaceInfoDataProcessor.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -30,8 +28,6 @@ public class PlaceInfoDataProcessor {
 	/**
 	 * 장소 정보를 다운로드하여 db에 저장
 	 */
-	//TODO 애플리케이션 시작시 해당 메서드 실행하는 걸 테스트할 방법 필요
-//	@EventListener(ApplicationReadyEvent.class)
 	public void process() {
 		log.info("장소 정보 다운로드 및 저장 시작");
 		final InputStream fetch = placeInfoService.fetch();

--- a/src/main/java/hiyen/galmanhae/dataprocess/client/FeignConfig.java
+++ b/src/main/java/hiyen/galmanhae/dataprocess/client/FeignConfig.java
@@ -5,6 +5,7 @@ import feign.Retryer;
 import feign.codec.ErrorDecoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
 public class FeignConfig {
@@ -20,6 +21,7 @@ public class FeignConfig {
 	}
 
 	@Bean
+	@Profile("prod") // prod 환경에서만 사용
 	public Retryer retryer() {
 		return new Retryer.Default();
 	}

--- a/src/test/java/hiyen/galmanhae/dataprocess/DataProcessInitializerTest.java
+++ b/src/test/java/hiyen/galmanhae/dataprocess/DataProcessInitializerTest.java
@@ -1,0 +1,27 @@
+package hiyen.galmanhae.dataprocess;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("prod")
+class DataProcessInitializerTest {
+
+	@MockBean
+	private PlaceInfoDataProcessor placeInfoDataProcessor;
+
+	@MockBean
+	private DataProcessor dataProcessor;
+
+	@DisplayName("애플리케이션 시작시 필요한 데이터를 처리한다")
+	@Test
+	void testInit() {
+		verify(dataProcessor, times(1)).process();
+		verify(placeInfoDataProcessor, times(1)).process();
+	}
+}


### PR DESCRIPTION
#### PR 설명

~~(#14 의 커밋이 반영되어 있습니다. #14가 merge되면 rebase하여 해당 이슈관련 커밋만 남기도록 하겠습니다. 이 PR에서 보실 커밋은 [a3cee73](https://github.com/jinkshower/galmanhae/commit/a3cee73427becfa8d61b9f929f91616f59c90c3e) 입니다)~~

Closes #12 

- DataProcessInitializer 빈을 prod 프로파일에서만 생성, 이 빈에 데이터 초기화 로직을 넣음.

- 애플리케이션 시작시 DataProcessor, PlaceInfoDataProcessor가 호출되게 하고 스케쥴러를 이용해 매 정시마다 DataProcessor가 최신의 데이터를 Place로 저장합니다. 

- @PostConstruct, @Scheduled를 사용하는 이상 프로덕션은 상관없지만 모든 @SpringBootTest에서 해당 메서드들의 실행을 신경써야 하는 상황이 올거라고 생각되어, mocking을 더 일찍하는 등의 방법보다는 아예 실행환경을 나누는게 좀 더 편하게 테스트를 작성할거라 생각되었습니다.

+[caa8746](https://github.com/jinkshower/galmanhae/pull/16/commits/caa874687e9a1f20e87013e210c392f87829f0c6)는 CI 중 Feign의 실패시 재시도가 현재 default로 5번인데 timeout테스트에서 너무 많은 시간이 걸려 prod환경에서만 적용하는 커밋입니다.

#### PR전 체크리스트

- [x] 코드 포맷터를 적용했습니다
- [x] 변경에 해당하는 테스트(단위 or 통합)를 작성했습니다
