### PR TITLE
docker 네트워크 환경을 변경한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,5 +70,5 @@ jobs:
             sudo docker stop galmanhae || true
             sudo docker rm galmanhae || true
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/galmanhae:latest
-            sudo docker run -d -p 8080:8080 -p 8040:8040 --name galmanhae -v /home/${{ secrets.HOST_USERNAME }}/log:/log ${{ secrets.DOCKER_USERNAME }}/galmanhae:latest
+            sudo docker run -d --network host --name galmanhae -v /home/${{ secrets.HOST_USERNAME }}/log:/log ${{ secrets.DOCKER_USERNAME }}/galmanhae:latest
             sudo docker image prune -f

--- a/src/main/java/hiyen/galmanhae/dataprocess/WeatherCongestionDataProcessor.java
+++ b/src/main/java/hiyen/galmanhae/dataprocess/WeatherCongestionDataProcessor.java
@@ -64,7 +64,7 @@ public class WeatherCongestionDataProcessor {
 	private CompletableFuture<WeatherAndCongestion> toFuture(final Place place) {
 		return CompletableFuture.supplyAsync(() -> fetch(place), weatherCongestionAPIThreadPool)
 			.exceptionally(exception -> {
-				log.info("외부 API 호출 및 가져오기에 실패했습니다: 장소: {}. Error: {}. 현재 시간 : {}", place, exception, LocalDateTime.now());
+				log.debug("외부 API 호출 및 가져오기에 실패했습니다: 장소: {}. Error: {}. 현재 시간 : {}", place, exception, LocalDateTime.now());
 				return null;
 			});
 	}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,13 +6,11 @@
     value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
 
   <springProfile name="prod">
-    <include resource="console-appender.xml"/>
     <include resource="info-appender.xml"/>
     <include resource="warn-appender.xml"/>
     <include resource="error-appender.xml"/>
 
     <root level="INFO">
-      <appender-ref ref="CONSOLE"/>
       <appender-ref ref="FILE-INFO"/>
       <appender-ref ref="FILE-WARN"/>
       <appender-ref ref="FILE-ERROR"/>


### PR DESCRIPTION
#### PR 설명

Closes #35 

성능테스트에서 일정 시간(3~4분)마다 2, 30초씩 응답시간이 치솟는 현상이 발생함

![image](https://github.com/user-attachments/assets/c7328cfd-54ae-4278-a3c3-d19045b8d360)
(p99의 응답시간이 30초가량씩 치솟음)

-> 해당 패턴이 부하와 상관없이, 데이터의 양과 상관없이 일정하게 반복됨. (자세한 성능기록 결과들은 [기술문서_성능테스트](https://jinkshower.notion.site/8acd3234d7234d9fbe57709d8d4aee87) 참고)

CPU, 메모리는 모두 안정적이었으며 DB Connection pool 커넥션 에러 없음, mysql의 슬로우 쿼리 로그 모두 깨끗함. 이에 의심되는 부분을 하나씩 고쳐가며 (이슈에서 언급한 osiv, 로깅설정 등) 테스트 했으나 현상이 나아지지 않음. 

- 로컬에서 성능테스트를 했을 때는 같은 현상이 전혀 발생하지 않음 -> 운영 서버의 네트워크 환경으로 범위를 좁힘

- tcpdump를 기록, WireShark를 통해 분석함. 

![image](https://github.com/user-attachments/assets/fd5c394f-23bb-40e9-be7a-2234d542e6ea)

-> `docker 컨테이너 내부 ip:같은 포트`,  `서버 ip:같은 포트`일때 서버 ip를 쓰는 커넥션은 정상적으로 정보를 주고 받고 docker 컨테이너 내부 ip를 쓰는 커넥션은 오류 재전송을 계속 반복하고 있음. 가상 네트워크 격리가 제대로 되지 않고 있음

-> docker로 애플리케이션만 띄우고 이외에 컨테이너끼리 소통하고 있지 않으므로 host로 서버의 네트워크 인터페이스를 사용하게 변경

![image](https://github.com/user-attachments/assets/fd2c75bd-1520-4e04-bcff-ee6afceb16d5)

해당 사항 적용 후 p99 응답시간이 목표로 했던 1초 미만으로 줄어들었음을 확인 

#### PR전 체크리스트

- [x] 코드 포맷터를 적용했습니다
- [x] 변경에 해당하는 테스트(단위 or 통합)를 작성했습니다

