### PR TITLE
웹 페이지 UX를 개선한다 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > 지금 서울, 이 장소 갈만해? 👉 https://galmanhae.site/
 
+<img src="https://github.com/user-attachments/assets/9bf6f420-1973-4029-85c3-aeb7cdddca43" alt="image" width="400"/>
+
 ## 📖 Description
 
 서울에서 외출을 하려는데, 그 장소의 날씨는 좋은 지, 사람은 너무 많지 않을 지 고민한 적 없으신가요?
@@ -50,6 +52,11 @@
 에서 확인 할 수 있습니다.
 
 ## Project Structure
+
+<img src="https://github.com/user-attachments/assets/9dcfc3c7-75ef-4e08-a529-78d7dae2d2f8" alt="Project Structure" width="600"/>
+
+<details>
+  <summary>Click</summary>
 
 ```markdown
 ├── GalmanhaeApplication.java
@@ -125,5 +132,5 @@
 └── exception
 ├── ErrorResponse.java
 └── GlobalExceptionHandler.java
-
+</details>
 ```

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,3 +1,20 @@
+/* 전체 레이아웃 */
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+/* 지도 영역 */
+#map {
+  width: 100%;
+  height: 100%;
+  transition: width 0.3s;
+}
+
+/* place-info 스타일 */
 #place-info {
   padding: 20px;
   font-family: Arial, sans-serif;
@@ -23,20 +40,7 @@
   color: #555;
 }
 
-html, body {
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  display: flex;
-}
-
-#map {
-  width: 100%;
-  height: 100%;
-  transition: width 0.3s;
-}
-
+/* placeInfoContainer 스타일 - 기본적으로 숨김 처리 */
 #placeInfoContainer {
   display: none;
   width: 0;
@@ -46,6 +50,7 @@ html, body {
   padding: 20px;
 }
 
+/* 검색창 스타일 */
 #search-container {
   position: absolute;
   top: 10px;
@@ -59,15 +64,17 @@ html, body {
   align-items: center;
 }
 
+/* 검색창 입력 필드 */
 #search-container input {
   width: 300px;
   padding: 10px;
-  border: transparent;
+  border: none; /* 테두리 제거 */
   border-radius: 3px;
   margin-right: 10px;
   background-color: lightgrey;
 }
 
+/* 검색 버튼 */
 #search-container button {
   padding: 10px 20px;
   background-color: #df6658;
@@ -76,7 +83,7 @@ html, body {
   cursor: pointer;
 }
 
-
+/* 검색 결과 스타일 */
 #search-results {
   position: absolute;
   top: 100%; /* 검색창 바로 아래에 위치 */
@@ -97,4 +104,60 @@ html, body {
 
 .search-result-item:hover {
   background-color: #f0f0f0;
+}
+
+/* 반응형 디자인 적용 */
+/* 태블릿 이하 크기 (max-width: 1024px) */
+@media (max-width: 1024px) {
+  #search-container input {
+    width: 250px; /* 태블릿에서 검색창 크기 조정 */
+  }
+
+  #search-container button {
+    padding: 8px 16px; /* 버튼 크기 조정 */
+  }
+}
+
+/* 모바일 크기 (max-width: 768px) */
+@media (max-width: 768px) {
+  #search-container input {
+    width: 200px; /* 모바일 화면에서 검색창 크기 줄임 */
+  }
+
+  #search-container button {
+    padding: 8px 16px; /* 모바일 화면에서 버튼 크기 조정 */
+  }
+
+  /* place-info가 화면 아래로 작아지는 설정 */
+  #place-info h2 {
+    font-size: 20px;
+    padding: 8px;
+  }
+
+  #place-info p {
+    font-size: 12px;
+    margin-bottom: 8px;
+  }
+}
+
+/* 작은 모바일 화면 (max-width: 480px) */
+@media (max-width: 480px) {
+  #search-container input {
+    width: 150px; /* 더 작은 화면에서 검색창 크기 줄임 */
+  }
+
+  #search-container button {
+    padding: 6px 12px; /* 작은 화면에서 버튼 크기 조정 */
+  }
+
+  /* place-info 텍스트 더 작게 */
+  #place-info h2 {
+    font-size: 18px;
+    padding: 6px;
+  }
+
+  #place-info p {
+    font-size: 11px;
+    margin-bottom: 6px;
+  }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -161,3 +161,52 @@ html, body {
     margin-bottom: 6px;
   }
 }
+
+/* 오버레이 스타일 */
+.overlay-container {
+  position: relative;
+  background-color: white;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  padding: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  font-family: Arial, sans-serif;
+}
+
+.overlay-content {
+  width: 200px;
+}
+
+.overlay-content h2 {
+  font-size: 18px;
+  margin: 0 0 10px 0;
+  background-color: #df6658;
+  color: white;
+  padding: 5px;
+  border-radius: 3px;
+}
+
+.overlay-content p {
+  font-size: 14px;
+  margin: 5px 0;
+  color: #333;
+}
+
+.overlay-content strong {
+  font-weight: bold;
+  color: #555;
+}
+
+.overlay-content .close-overlay {
+  background-color: #df6658;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
+  border-radius: 3px;
+  margin-top: 10px;
+}
+
+.overlay-content .close-overlay:hover {
+  background-color: #c04b46;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -11,7 +11,8 @@ html, body {
 #map {
   width: 100%;
   height: 100%;
-  transition: width 0.3s;
+  position: relative; /* 지도 영역을 상대적으로 설정 */
+  z-index: 1; /* 지도는 하위 레이어에 존재 */
 }
 
 /* place-info 스타일 */
@@ -208,5 +209,24 @@ html, body {
 }
 
 .overlay-content .close-overlay:hover {
+  background-color: #c04b46;
+}
+
+/* 내 위치로 버튼 */
+#current-location-button {
+  position: absolute;
+  bottom: 20px; /* 화면 하단에서 20px */
+  right: 20px; /* 화면 오른쪽에서 20px */
+  z-index: 100; /* 버튼이 지도 위에 나타나도록 설정 */
+  padding: 10px 20px;
+  background-color: #df6658;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+#current-location-button:hover {
   background-color: #c04b46;
 }

--- a/src/main/resources/static/js/MapModule.js
+++ b/src/main/resources/static/js/MapModule.js
@@ -1,11 +1,10 @@
-import {PlaceInfoModule} from './PlaceInfoModule.js';
-
 export class MapModule {
   constructor(mapContainerId, options) {
     this.mapContainer = document.getElementById(mapContainerId);
     this.mapOptions = options;
     this.map = this.initializeMap();
     this.loadAllPlaces();
+    this.customOverlay = null; // 오버레이 저장용 변수
   }
 
   initializeMap() {
@@ -22,26 +21,14 @@ export class MapModule {
         imageOption);
     const marker = new kakao.maps.Marker({
       position: markerPosition,
-      image: markerImage
+      image: markerImage,
     });
     marker.setMap(this.map);
-
-    const infowindow = this.createInfoWindow(place.name);
-
-    // 마우스 오버 시 인포윈도우 열기
-    kakao.maps.event.addListener(marker, 'mouseover', () => {
-      infowindow.open(this.map, marker);
-    });
-
-    // 마우스 아웃 시 인포윈도우 닫기
-    kakao.maps.event.addListener(marker, 'mouseout', () => {
-      infowindow.close();
-    });
 
     // 마커 클릭 시 장소 정보 가져오기 및 지도 중심 이동
     kakao.maps.event.addListener(marker, 'click', () => {
       this.setCenter(markerPosition);
-      this.fetchPlaceDetails(place.placeId);
+      this.fetchPlaceDetails(place.placeId, markerPosition);
     });
   }
 
@@ -58,44 +45,73 @@ export class MapModule {
     }
   }
 
-  createInfoWindow(content) {
-    return new kakao.maps.InfoWindow({
-      content: '<div style="padding:5px;">' + content + '</div>'
-    });
-  }
-
   loadAllPlaces() {
     axios.get('/api/places')
-    .then(response => {
-      response.data.forEach(place => {
+    .then((response) => {
+      response.data.forEach((place) => {
         this.addMarker(place);
       });
     })
-    .catch(error => {
+    .catch((error) => {
       console.error('Error fetching places:', error);
     });
   }
 
-  adjustMapSize() {
-    this.mapContainer.style.width = "80%";
-    const placeInfoContainer = document.getElementById('placeInfoContainer');
-    placeInfoContainer.style.width = "20%";
-    placeInfoContainer.style.display = "block";
-  }
-
   setCenter(position) {
+    // 지도 이동
     this.map.setCenter(position);
   }
 
-  fetchPlaceDetails(placeId) {
+  fetchPlaceDetails(placeId, position) {
     axios.get(`/api/places/${placeId}`)
-    .then(response => {
+    .then((response) => {
       const placeDetails = response.data;
-      PlaceInfoModule.displayPlaceInfo(placeDetails);
-      this.adjustMapSize();
+
+      // 지도 이동 후 오버레이 표시
+      this.setCenter(position); // 지도 이동
+      setTimeout(() => {
+        this.showCustomOverlay(placeDetails, position); // 오버레이 표시
+      }, 200); // 약간의 지연 시간 적용
     })
-    .catch(error => {
+    .catch((error) => {
       console.error('Error fetching place details:', error);
+    });
+  }
+
+  // 마커 클릭 시 오버레이로 정보 표시
+  showCustomOverlay(placeDetails, position) {
+    // 이전 오버레이가 있다면 제거
+    if (this.customOverlay) {
+      this.customOverlay.setMap(null);
+    }
+
+    // 오버레이 내용 생성
+    const overlayContent = `
+      <div class="overlay-container">
+        <div class="overlay-content">
+          <h2>${placeDetails.name}</h2>
+          <p>${placeDetails.goOutLevelDescription}</p>
+          <p><strong>날씨:</strong> ${placeDetails.weatherDescription}</p>
+          <p><strong>온도:</strong> ${placeDetails.weatherTemp}도</p>
+          <p><strong>강수 확률:</strong> ${placeDetails.weatherRaining}%</p>
+          <p><strong>혼잡도:</strong> ${placeDetails.congestionDescription}</p>
+          <p><strong>실시간 인구 수:</strong> ${placeDetails.congestionPeople}명</p>
+          <button class="close-overlay">닫기</button>
+        </div>
+      </div>
+    `;
+
+    // 오버레이 생성
+    this.customOverlay = new kakao.maps.CustomOverlay({
+      position: position,
+      content: overlayContent,
+      yAnchor: 1,
+      map: this.map,
+    });
+
+    // 닫기 버튼 이벤트 처리
+    document.querySelector('.close-overlay').addEventListener('click', () => {
+      this.customOverlay.setMap(null);
     });
   }
 }

--- a/src/main/resources/static/js/SearchModule.js
+++ b/src/main/resources/static/js/SearchModule.js
@@ -1,5 +1,3 @@
-import {PlaceInfoModule} from './PlaceInfoModule.js';
-
 export class SearchModule {
   constructor(mapModule) {
     this.mapModule = mapModule;
@@ -55,8 +53,11 @@ export class SearchModule {
       placeElement.innerText = placeSearchResponse.placeName;
 
       placeElement.addEventListener('click', () => {
-        this.fetchPlaceDetails(placeSearchResponse.placeId,
-            placeSearchResponse.latitude, placeSearchResponse.longitude);
+        this.fetchPlaceDetails(
+            placeSearchResponse.placeId,
+            placeSearchResponse.latitude,
+            placeSearchResponse.longitude
+        );
         resultsContainer.style.display = 'none'; // 검색 결과를 클릭 시 결과 창을 숨깁니다.
       });
 
@@ -70,11 +71,11 @@ export class SearchModule {
     axios.get(`/api/places/${placeId}`)
     .then(response => {
       const placeDetails = response.data;
-      PlaceInfoModule.displayPlaceInfo(placeDetails);
-      this.mapModule.adjustMapSize();
+      const position = new kakao.maps.LatLng(latitude, longitude);
 
-      // 검색 결과 클릭 시 해당 위치로 지도 중심 이동
-      this.mapModule.setCenter(new kakao.maps.LatLng(latitude, longitude));
+      // 지도 중심 이동 및 오버레이 표시
+      this.mapModule.setCenter(position);
+      this.mapModule.showCustomOverlay(placeDetails, position);
     })
     .catch(error => {
       console.error('Error fetching place details:', error);

--- a/src/main/resources/static/js/SearchModule.js
+++ b/src/main/resources/static/js/SearchModule.js
@@ -11,10 +11,21 @@ export class SearchModule {
     const searchButton = document.querySelector('#search-container button');
     const keyWordInput = document.querySelector('#keyword');
 
+    // '갈만해?' 버튼 클릭 시 검색 수행
     searchButton.addEventListener('click', () => {
       const keyWord = keyWordInput.value.trim();
       if (keyWord) {
         this.searchPlaces(keyWord);
+      }
+    });
+
+    // 엔터 키 입력 시 검색 수행
+    keyWordInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        const keyWord = keyWordInput.value.trim();
+        if (keyWord) {
+          this.searchPlaces(keyWord);
+        }
       }
     });
   }

--- a/src/main/resources/templates/map.html
+++ b/src/main/resources/templates/map.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>갈만해?</title>
   <link href="/css/style.css" rel="stylesheet"> <!-- 스타일시트 파일 경로로 대체 -->
 </head>

--- a/src/main/resources/templates/map.html
+++ b/src/main/resources/templates/map.html
@@ -17,6 +17,9 @@
 <div id="map"></div>
 <div id="placeInfoContainer"></div> <!-- 오른쪽 정보 창 영역 -->
 
+<!-- 오른쪽 하단에 위치할 버튼 -->
+<button id="current-location-button">내 위치로</button>
+
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script> <!-- axios 라이브러리 로드 -->
 <script
     th:src="'//dapi.kakao.com/v2/maps/sdk.js?appkey=' + ${appKey} + '&libraries=services'"></script>


### PR DESCRIPTION
#### PR 설명

Closes #38 

사용자 웹 페이지 UX 개선

1. 모바일 디바이스에서도 화면이 일그러지지 않게 viewport 태그 추가
2. 장소 정보 제공을 마커 근처의 오버레이로 제공, 닫기 버튼 추가
3. 엔터로 검색해도 결과가 나오게 변경
4. 사용자 위치기반 서비스 제공. 위치를 차단할 시 기본 서울시청이 지도의 중심이 되게 함.

#### PR전 체크리스트

- [x] 코드 포맷터를 적용했습니다
- [x] 변경에 해당하는 테스트(단위 or 통합)를 작성했습니다
